### PR TITLE
Add unit tests for CocktailDetails helpers

### DIFF
--- a/app/src/test/java/com/hyeonwoo/compose_cocktail_recipes/ui/detail/CocktailDetailsTest.kt
+++ b/app/src/test/java/com/hyeonwoo/compose_cocktail_recipes/ui/detail/CocktailDetailsTest.kt
@@ -1,0 +1,24 @@
+package com.hyeonwoo.compose_cocktail_recipes.ui.detail
+
+import com.hyeonwoo.compose_cocktail_recipes.model.DummyDrink
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CocktailDetailsTest {
+
+    private val drink = DummyDrink()
+
+    @Test
+    fun ingredients_returnsExpectedList() {
+        val expected = listOf("Gin", "Dry Vermouth", "Olive")
+        val result = ingredients(drink)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun measures_returnsExpectedList() {
+        val expected = listOf("1 2/3 oz", "1/3 oz", "1")
+        val result = measures(drink)
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
## Summary
- add `CocktailDetailsTest` for `ingredients` and `measures`

## Testing
- `./gradlew testDebugUnitTest` *(fails: Unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6850c0ea8240832f89d330e5952ffcde