### PR TITLE
Fix GitHub Actions name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The project's database used [ThecocktailDB](https://www.thecocktaildb.com/)
 + Gson
 + Coil
 + Timber
-+ Github Action (CI/CD)
++ GitHub Actions (CI/CD)
 
 
 ## CI / CD


### PR DESCRIPTION
## Summary
- fix name of GitHub Actions in technology list

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6850c0e8f274832fa85b167d725ab7b5