### PR TITLE
Fix placeholder text in DummyDrink

### DIFF
--- a/app/src/main/java/com/hyeonwoo/compose_cocktail_recipes/model/Drink.kt
+++ b/app/src/main/java/com/hyeonwoo/compose_cocktail_recipes/model/Drink.kt
@@ -69,7 +69,7 @@ fun DummyDrink(): Drink {
         strIBA = "unforgettables",
         strAlcoholic = "Alcoholic",
         strGlass = "Cocktail glass",
-        strInstructions = "traight: Pour all ingredients into mixing glass with ice cubes. Stir well. Strain in chilled martini cocktail glass. Squeeze oil from lemon peel onto the drink, or garnish with olive.",
+        strInstructions = "Straight: Pour all ingredients into mixing glass with ice cubes. Stir well. Strain in chilled martini cocktail glass. Squeeze oil from lemon peel onto the drink, or garnish with olive.",
         strInstructionsES = null,
         strInstructionsDE = null,
         strInstructionsFR = null,


### PR DESCRIPTION
## Summary
- fix DummyDrink instructions text so it starts with `Straight:`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6850c0e62ba4832fab1d19ef39873a4e